### PR TITLE
fix build errors in xcode 16.3

### DIFF
--- a/Source/PLCrashMachExceptionServer.m
+++ b/Source/PLCrashMachExceptionServer.m
@@ -520,7 +520,6 @@ static mach_msg_return_t exception_server_reply (PLRequest_exception_raise_t *re
  * if the exception was not handled, or forwarding failed.
  *
  * @par In-Process Operation
- *
  * When operating in-process, handling the exception replies internally breaks external debuggers,
  * as they assume it is safe to leave our thread suspended. This results in the target thread never resuming,
  * as our thread never wakes up to reply to the message, or to handle future messages.

--- a/Source/PLCrashReportProcessorInfo.m
+++ b/Source/PLCrashReportProcessorInfo.m
@@ -35,7 +35,6 @@
  * to differentiate between processor variants (eg, ARMv6 vs ARMv7).
  *
  * @par CPU Type Encodings
- *
  * The wire format maintains support for multiple CPU type encodings; it is expected that different operating
  * systems may target different processors, and the reported CPU type and subtype information may not be
  * easily or directly expressed when not using the vendor's own defined types.

--- a/Source/PLCrashReporter.m
+++ b/Source/PLCrashReporter.m
@@ -535,7 +535,6 @@ static PLCrashReporter *sharedReporter = nil;
  * not be enabled.
  *
  * @par Registering Multiple Reporters
- *
  * Only one PLCrashReporter instance may be enabled in a process; attempting to enable an additional instance
  * will return NO, and the reporter will not be enabled. This restriction may be removed in a future release.
  */
@@ -561,7 +560,6 @@ static PLCrashReporter *sharedReporter = nil;
  * not be enabled.
  *
  * @par Registering Multiple Reporters
- *
  * Only one PLCrashReporter instance may be enabled in a process; attempting to enable an additional instance
  * will return NO and a PLCrashReporterErrorResourceBusy error, and the reporter will not be enabled.
  * This restriction may be removed in a future release.

--- a/Source/PLCrashReporterConfig.h
+++ b/Source/PLCrashReporterConfig.h
@@ -69,13 +69,11 @@ typedef NS_ENUM(NSUInteger, PLCrashReporterSignalHandlerType) {
      * by PLCrashReporter.
      *
      * @par Mac OS X
-     *
      * On Mac OS X, the Mach exception implementation is fully supported, using publicly available API -- note,
      * however, that some kernel-internal constants, as well as architecture-specific trap information,
      * may be required to fully interpret a Mach exception's root cause.
      *
      * @par iOS
-     *
      * On iOS, the APIs required for a complete implementation are not fully public.
      *
      * The exposed surface of undocumented API usage is relatively low, and there has been strong user demand to
@@ -84,13 +82,11 @@ typedef NS_ENUM(NSUInteger, PLCrashReporterSignalHandlerType) {
      * to disable its inclusion or use, respectively.
      *
      * @par Debugger Incompatibility
-     *
      * The Mach exception handler executes in-process, and will interfere with debuggers when they attempt to
      * suspend all active threads (which will include the Mach exception handler). Mach-based handling
      * should not be used when a debugger is attached.
      *
      * @par More Details
-     *
      * For more information, refer to @ref mach_exceptions.
      */
     PLCrashReporterSignalHandlerTypeMach = 1


### PR DESCRIPTION
error was `Empty paragraph passed to '@par' command`