### PR TITLE
Fix for Xcode 26 issues

### DIFF
--- a/Source/PLCrashMacros.h
+++ b/Source/PLCrashMacros.h
@@ -31,6 +31,9 @@
 
 #include <assert.h>
 
+#include <stdlib.h> // pulls in declaration of malloc, free
+#include <string.h>
+
 #if defined(__cplusplus)
 #   define PLCR_EXPORT extern "C"
 #   define PLCR_C_BEGIN_DECLS extern "C" {


### PR DESCRIPTION
> Use of undeclared identifier 'malloc'; did you mean 'valloc'?
Use of undeclared identifier 'free'
Use of undeclared identifier 'malloc'; did you mean 'valloc'? Use of undeclared identifier 'free'